### PR TITLE
Highlight cached cells in LatentGrid

### DIFF
--- a/src/playcanvas-esm.d.ts
+++ b/src/playcanvas-esm.d.ts
@@ -1,0 +1,3 @@
+declare module 'playcanvas/scripts/esm/camera-controls.mjs';
+declare module 'playcanvas/scripts/esm/xr-controllers.mjs';
+declare module 'playcanvas/scripts/esm/xr-navigation.mjs';


### PR DESCRIPTION
## Summary
- expose a `markCellCached` helper from LatentGrid and track visited cells
- draw cached cells with a subtle overlay
- parse row/col from model path and notify grid when loading succeeds
- provide TypeScript declarations for the playcanvas helper modules
- maintain cache using a 2D boolean array instead of a Set

## Testing
- `npm run tsc` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68419fb5bd188320b1bd2475397ea335