### PR TITLE
Fix tests after canvas resizing update

### DIFF
--- a/tests/bulkDownload.test.ts
+++ b/tests/bulkDownload.test.ts
@@ -32,6 +32,7 @@ vi.mock('playcanvas', () => {
     parent: Entity | null = null;
     children: Entity[] = [];
     gsplat: any = { asset: null, instance: { sorter: new EventEmitter() } };
+    setLocalPosition = vi.fn();
     constructor(name = '') {
       super();
       this.name = name;
@@ -92,17 +93,33 @@ vi.mock('playcanvas', () => {
     root = new Entity('root');
     assets = new AssetRegistry();
     renderNextFrame = vi.fn();
+    setCanvasFillMode = vi.fn();
+    setCanvasResolution = vi.fn();
+    resizeCanvas = vi.fn();
+    graphicsDevice = { canvas: { style: {} } } as any;
   }
 
   function registerScript() {}
 
-  return { Entity, Asset, Application, registerScript };
+  return {
+    Entity,
+    Asset,
+    Application,
+    registerScript,
+    FILLMODE_NONE: 0,
+    RESOLUTION_AUTO: 'auto',
+  };
 });
 
 let pcAppEl: HTMLElement & { app: any };
 
 beforeEach(async () => {
   vi.useFakeTimers();
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
   (global as any).fetch = vi.fn(
     () =>
       new Promise((resolve) =>

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -34,6 +34,7 @@ vi.mock('playcanvas', () => {
     parent: Entity | null = null;
     children: Entity[] = [];
     gsplat: any = { asset: null, instance: { sorter: new EventEmitter() } };
+    setLocalPosition = vi.fn();
     constructor(name = '') {
       super();
       this.name = name;
@@ -94,13 +95,24 @@ vi.mock('playcanvas', () => {
     root = new Entity('root');
     assets = new AssetRegistry();
     renderNextFrame = vi.fn();
+    setCanvasFillMode = vi.fn();
+    setCanvasResolution = vi.fn();
+    resizeCanvas = vi.fn();
+    graphicsDevice = { canvas: { style: {} } } as any;
   }
 
   function registerScript(...args: any[]) {
     registerScriptSpy(...args);
   }
 
-  return { Entity, Asset, Application, registerScript };
+  return {
+    Entity,
+    Asset,
+    Application,
+    registerScript,
+    FILLMODE_NONE: 0,
+    RESOLUTION_AUTO: 'auto',
+  };
 });
 
 let app: any;
@@ -108,6 +120,11 @@ let pcAppEl: HTMLElement & { app: any };
 
 beforeEach(async () => {
   vi.useFakeTimers();
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
   (global as any).fetch = vi.fn(
     () =>
       new Promise((resolve) =>

--- a/tests/modelSwitch.test.ts
+++ b/tests/modelSwitch.test.ts
@@ -32,6 +32,7 @@ vi.mock('playcanvas', () => {
     parent: Entity | null = null;
     children: Entity[] = [];
     gsplat: any = { asset: null, instance: { sorter: new EventEmitter() } };
+    setLocalPosition = vi.fn();
     constructor(name = '') {
       super();
       this.name = name;
@@ -92,11 +93,22 @@ vi.mock('playcanvas', () => {
     root = new Entity('root');
     assets = new AssetRegistry();
     renderNextFrame = vi.fn();
+    setCanvasFillMode = vi.fn();
+    setCanvasResolution = vi.fn();
+    resizeCanvas = vi.fn();
+    graphicsDevice = { canvas: { style: {} } } as any;
   }
 
   function registerScript() {}
 
-  return { Entity, Asset, Application, registerScript };
+  return {
+    Entity,
+    Asset,
+    Application,
+    registerScript,
+    FILLMODE_NONE: 0,
+    RESOLUTION_AUTO: 'auto',
+  };
 });
 
 let app: any;
@@ -105,6 +117,11 @@ let pcAppEl: HTMLElement;
 beforeEach(async () => {
   vi.resetModules();
   vi.useFakeTimers();
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
   (global as any).fetch = vi.fn(
     () =>
       new Promise((resolve) =>


### PR DESCRIPTION
## Summary
- extend playcanvas mocks in tests with canvas-resizing API
- stub ResizeObserver in tests
- adjust mock entities to include `setLocalPosition`

## Testing
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_68501fe077f483208030853cc2ae40d5